### PR TITLE
Restore Instagram feed preview on homepage

### DIFF
--- a/_includes/instafeed.html
+++ b/_includes/instafeed.html
@@ -1,0 +1,20 @@
+<div id="instafeed"></div>
+<script src="{{ '/js/instafeed.js' | relative_url }}"></script>
+{% raw %}
+<script type="text/javascript">
+  const accessToken = '601088313.1677ed0.df46ed351a5f44bab606823c253be9ff';
+  // Refresh the long-lived Instagram access token on each page load
+  // https://github.com/stevenschobert/instafeed.js/issues/747
+  fetch(`https://graph.instagram.com/refresh_access_token?grant_type=ig_refresh_token&access_token=${accessToken}`);
+  var feed = new Instafeed({
+    get: 'user',
+    userId: 601088313,
+    accessToken: accessToken,
+    links: true,
+    limit: 6,
+    resolution: 'thumbnail',
+    template: '<a href="{{link}}"><img src="{{image}}" /></a>'
+  });
+  feed.run();
+</script>
+{% endraw %}

--- a/index.md
+++ b/index.md
@@ -3,6 +3,8 @@ layout: default
 title: Joachim Daiber
 ---
 
+<div id="frontpage" markdown="1">
+
 ## About me
 
 I am an applied scientist focused on machine learning and practical engineering. I was a co-founder and CTO of Objective, Inc. ([TechCrunch](https://techcrunch.com/2023/10/18/objective-emerges-from-stealth-to-deliver-multimodal-search-to-developers-as-an-api-platform/)), which was acquired by Upwork in November 2024.
@@ -51,3 +53,7 @@ in applications and evaluation of large language and vision models, machine tran
 {% endif %}
 
 {% endfor %}
+
+{% include instafeed.html %}
+
+</div>


### PR DESCRIPTION
## Summary
- Reintroduce Instagram feed on homepage with automatic access token refresh
- Ensure homepage markdown renders by enabling Markdown processing and moving feed markup to an include

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68912d3981dc832691a4790ccf470691